### PR TITLE
Add viewport metadata to ID card templates

### DIFF
--- a/resources/views/idcards/legal-multipage.blade.php
+++ b/resources/views/idcards/legal-multipage.blade.php
@@ -2,6 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
   @page { size: Legal landscape; margin: 10mm; }
   body { font-family: DejaVu Sans, Arial, Helvetica, sans-serif; font-size: 9pt; background:#fff; }

--- a/resources/views/idcards/legal-side-by-side-portrait.blade.php
+++ b/resources/views/idcards/legal-side-by-side-portrait.blade.php
@@ -2,6 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
   @page { size: Legal portrait; margin: 10mm; }
 

--- a/resources/views/idcards/legal-side-by-side.blade.php
+++ b/resources/views/idcards/legal-side-by-side.blade.php
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
         @page { size: Legal landscape; margin: 10mm; }
 


### PR DESCRIPTION
## Summary
- ensure ID card Blade templates include viewport meta tag for proper scaling on mobile

## Testing
- `npm run build`
- `composer test` *(fails: Failed to open stream: No such file or directory)*
- `composer install` *(fails: GitHub API 403 requires authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68b8695eaa048326b24fb85d2eab803c