### PR TITLE
Fix signature layout overflow in ID card templates

### DIFF
--- a/resources/views/idcards/legal-multipage.blade.php
+++ b/resources/views/idcards/legal-multipage.blade.php
@@ -37,7 +37,7 @@
 
   /* FRONT bottom bar */
   .bottom { position:absolute; left:0; right:0; bottom:1.5mm; display:flex; justify-content:space-between; align-items:center; padding:0 3mm; }
-  .sig { font-size:6.5pt; text-align:center; width:24mm; color:#333; }
+  .sig { font-size:6.5pt; text-align:center; width:15mm; color:#333; }
   .qr  { width:18mm; height:18mm; border:0.2mm solid #c9c9c9; display:flex; align-items:center; justify-content:center; background:#fff; }
 
   /* ---------- BACK: আলাদা bottom bar যুক্ত ---------- */
@@ -103,9 +103,9 @@
           <div class="dept">{{ $e->department }}</div>
 
           <div class="bottom">
-            <div class="sig"><div style="height:10mm;"><img src="{{ asset('img/c-holder-sig.png') }}" alt="" style="height:10mm;"></div><div>Card Holder</div></div>
+            <div class="sig"><div style="height:10mm;"><img src="{{ asset('img/c-holder-sig.png') }}" alt="" style="width:100%; height:auto;"></div><div>Card Holder</div></div>
             <div class="qr">{!! QrCode::size(70)->margin(0)->generate(json_encode($e->qr_payload ?? ['id'=>$e->id])) !!}</div>
-            <div class="sig"><div style="height:10mm;"><img src="{{ asset('img/regi-sig.png') }}" alt="" style="height:10mm;"></div><div>Registrar</div></div>
+            <div class="sig"><div style="height:10mm;"><img src="{{ asset('img/regi-sig.png') }}" alt="" style="width:100%; height:auto;"></div><div>Registrar</div></div>
           </div>
 
           <div class="crop">

--- a/resources/views/idcards/legal-side-by-side-portrait.blade.php
+++ b/resources/views/idcards/legal-side-by-side-portrait.blade.php
@@ -44,7 +44,7 @@
   .role{ text-align:center; font-size:8pt; margin-top:0.5mm; color:#333; }
   .dept{ text-align:center; font-size:7.5pt; color:#333; }
   .bottom {position: absolute;left: 0;right: 0;bottom: 1.5mm;display: flex;justify-content: space-between;align-items: center;padding: 0 3mm;}
-  .sig{ font-size:6.5pt; text-align:center; width:24mm; color:#333; }
+  .sig{ font-size:6.5pt; text-align:center; width:15mm; color:#333; }
   .qr{ width:15mm; height:15mm; border:0.2mm solid #c9c9c9; display:flex; align-items:center; justify-content:center; background:#fff; }
   .qr-svg svg { width:15mm; height:15mm; display:block; }
 
@@ -97,9 +97,9 @@
                       <div class="role">{{ $e->designation }}</div>
                       <div class="dept">{{ $e->department }}</div>
                       <div class="bottom">
-                        <div class="sig"><div style="height:10mm;"><img src="{{ $cardSigSrc }}" alt="" style="height:10mm;"></div><div>Card Holder</div></div>
+                        <div class="sig"><div style="height:10mm;"><img src="{{ $cardSigSrc }}" alt="" style="width:100%; height:auto;"></div><div>Card Holder</div></div>
                           <div class="qr"><span class="qr-pdf qr-svg">{!! $qrSvg !!}</span></div>
-                        <div class="sig"><div style="height:10mm;"><img src="{{ $regiSigSrc }}" alt="" style="height:10mm;"></div><div>Registrar</div></div>
+                        <div class="sig"><div style="height:10mm;"><img src="{{ $regiSigSrc }}" alt="" style="width:100%; height:auto;"></div><div>Registrar</div></div>
                       </div>
                       <div class="crop"><div class="cm h tl"></div><div class="cm v tl"></div><div class="cm h tr"></div><div class="cm v tr"></div><div class="cm h bl"></div><div class="cm v bl"></div><div class="cm h br"></div><div class="cm v br"></div></div>
                     </div>
@@ -153,9 +153,9 @@
                 <div class="role">{{ $e->designation }}</div>
                 <div class="dept">{{ $e->department }}</div>
                 <div class="bottom">
-                  <div class="sig"><div style="height:10mm;"><img src="{{ $cardSigSrc }}" alt="" style="height:10mm;"></div><div>Card Holder</div></div>
+                  <div class="sig"><div style="height:10mm;"><img src="{{ $cardSigSrc }}" alt="" style="width:100%; height:auto;"></div><div>Card Holder</div></div>
                   <div class="qr">{!! QrCode::size(70)->margin(0)->generate($qrPayload) !!}</div>
-                  <div class="sig"><div style="height:10mm;"><img src="{{ $regiSigSrc }}" alt="" style="height:10mm;"></div><div>Registrar</div></div>
+                  <div class="sig"><div style="height:10mm;"><img src="{{ $regiSigSrc }}" alt="" style="width:100%; height:auto;"></div><div>Registrar</div></div>
                 </div>
                 <div class="crop"><div class="cm h tl"></div><div class="cm v tl"></div><div class="cm h tr"></div><div class="cm v tr"></div><div class="cm h bl"></div><div class="cm v bl"></div><div class="cm h br"></div><div class="cm v br"></div></div>
               </div>

--- a/resources/views/idcards/legal-side-by-side.blade.php
+++ b/resources/views/idcards/legal-side-by-side.blade.php
@@ -48,7 +48,7 @@
         .role{ text-align:center; font-size:8pt; margin-top:0.5mm; color:#333; }
         .dept{ text-align:center; font-size:7.5pt; color:#333; }
         .bottom {position: absolute;left: 0;right: 0;bottom: 1.5mm;display: flex;justify-content: space-between;align-items: center;padding: 0 3mm;}
-        .sig{ font-size:6.5pt; text-align:center; width:24mm; color:#333; }
+        .sig{ font-size:6.5pt; text-align:center; width:15mm; color:#333; }
         .qr{ width:15mm; height:15mm; border:0.2mm solid #c9c9c9; display:flex; align-items:center; justify-content:center; background:#fff; }
         .qr-svg svg { width:15mm; height:15mm; display:block; }
 
@@ -105,9 +105,9 @@
                                             <div class="role">{{ $e->designation }}</div>
                                             <div class="dept">{{ $e->department }}</div>
                                             <div class="bottom">
-                                                <div class="sig"><div style="height:10mm;"><img src="{{ $cardSig }}" alt="" style="height:10mm;"></div><div>Card Holder</div></div>
+                                                <div class="sig"><div style="height:10mm;"><img src="{{ $cardSig }}" alt="" style="width:100%; height:auto;"></div><div>Card Holder</div></div>
                                                 <div class="qr"><span class="qr-pdf qr-svg">{!! $qrSvg !!}</span></div>
-                                                <div class="sig"><div style="height:10mm;"><img src="{{ $regiSig }}" alt="" style="height:10mm;"></div><div>Registrar</div></div>
+                                                <div class="sig"><div style="height:10mm;"><img src="{{ $regiSig }}" alt="" style="width:100%; height:auto;"></div><div>Registrar</div></div>
                                             </div>
                                         </div>
 
@@ -175,9 +175,9 @@
                                 <div class="role">{{ $e->designation }}</div>
                                 <div class="dept">{{ $e->department }}</div>
                                 <div class="bottom">
-                                    <div class="sig"><div style="height:10mm;"><img src="{{ $cardSig }}" alt="" style="height:10mm;"></div><div>Card Holder</div></div>
+                                    <div class="sig"><div style="height:10mm;"><img src="{{ $cardSig }}" alt="" style="width:100%; height:auto;"></div><div>Card Holder</div></div>
                                     <div class="qr">{!! QrCode::size(70)->margin(0)->generate($qrPayload) !!}</div>
-                                    <div class="sig"><div style="height:10mm;"><img src="{{ $regiSig }}" alt="" style="height:10mm;"></div><div>Registrar</div></div>
+                                    <div class="sig"><div style="height:10mm;"><img src="{{ $regiSig }}" alt="" style="width:100%; height:auto;"></div><div>Registrar</div></div>
                                 </div>
                             </div>
 


### PR DESCRIPTION
## Summary
- reduce signature slot width and scale images to avoid bottom overflow
- ensure card holder and registrar signatures fit alongside QR code

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `php artisan test` *(fails: vendor/autoload.php missing; composer install requires network)*

------
https://chatgpt.com/codex/tasks/task_e_68b86ade8c308326b7e88108a3d9e67f